### PR TITLE
fix(build): Resolve build failures and align Docker image naming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ clean-local-files:
 	rm -rf ./scripts/helm_tmp ./scripts/helm_versions
 
 run-docker:
-	docker run -p 8080:8080 onap/org.onap.sdc.sdc-helm-validator:latest
+	docker run -p 8080:8080 onap/sdc-helm-validator:latest

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>${apache.commons.codec.version}</version>
+     <version>${apache.commons.codec.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,31 @@
   <name>helmvalidator</name>
   <description>Spring-Boot application for validating helm charts</description>
 
+   <repositories>
+    <repository>
+      <id>onap-releases</id>
+      <name>onap-releases</name>
+      <url>https://nexus.onap.org/content/repositories/releases/</url>
+    </repository>
+    <repository>
+      <id>onap-snapshots</id>
+      <name>onap-snapshots</name>
+      <url>https://nexus.onap.org/content/repositories/snapshots/</url>
+    </repository>
+  </repositories>
+   <pluginRepositories>
+    <pluginRepository>
+      <id>onap-releases</id>
+      <name>onap-releases</name>
+      <url>https://nexus.onap.org/content/repositories/releases/</url>
+    </pluginRepository>
+    <pluginRepository>
+      <id>onap-snapshots</id>
+      <name>onap-snapshots</name>
+      <url>https://nexus.onap.org/content/repositories/snapshots/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <properties>
     <java.version>11</java.version>
 


### PR DESCRIPTION
**The Problem**
The project currently has two main issues related to its build and local development setup:

- Build Failure: On a clean development environment, running mvn clean install fails with Non-resolvable parent POM and Plugin could not be resolved errors. This is because the required ONAP dependencies are hosted on a custom Nexus repository, not on the default Maven Central.

- Inconsistent Docker Image Name: The Docker image name specified in the Makefile (e.g., onap/org.onap.sdc.sdc-helm-validator:latest) was inconsistent with the standard image name defined in the pom.xml (onap/sdc-helm-validator:latest). This leads to discrepancies between the image built via Maven and the one managed by the make commands.

**The Solution**
This Pull Request addresses both issues with the following changes:

- Added Maven Repositories: The pom.xml has been updated to include <repositories> and <pluginRepositories> blocks pointing to the official ONAP Nexus repository. This allows Maven to successfully resolve and download all required parent POMs, dependencies, and plugins.

- Aligned Docker Image Name: The Docker image name in the Makefile has been corrected to match the definition in the pom.xml (onap/sdc-helm-validator). This ensures consistency between the Maven build process and the local make commands.

These changes make the build process more stable and succesfull